### PR TITLE
Add AI tools experience and services

### DIFF
--- a/src/components/experience/experience.css
+++ b/src/components/experience/experience.css
@@ -1,6 +1,6 @@
 .experience__container {
     display :grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 2rem;
     padding-bottom: 75px;
     padding-top: 50px;

--- a/src/components/experience/experience.jsx
+++ b/src/components/experience/experience.jsx
@@ -98,6 +98,46 @@ const experience = () => {
           </div>
 
         </div>
+        <div className="experience__ai">
+          <h3>AI Tools &amp; Software</h3>
+          <div className="experience__content">
+            <article className='experience__details'>
+              <BsPatchCheckFill className="experience__details-icon" />
+              <div>
+                <h4>GPT Pro</h4>
+                <small className='text-light'>Experienced</small>
+              </div>
+            </article>
+            <article className='experience__details'>
+              <BsPatchCheckFill className="experience__details-icon" />
+              <div>
+                <h4>Codex</h4>
+                <small className='text-light'>Experienced</small>
+              </div>
+            </article>
+            <article className='experience__details'>
+              <BsPatchCheckFill className="experience__details-icon" />
+              <div>
+                <h4>Operator</h4>
+                <small className='text-light'>Intermediate</small>
+              </div>
+            </article>
+            <article className='experience__details'>
+              <BsPatchCheckFill className="experience__details-icon" />
+              <div>
+                <h4>OpenAI API</h4>
+                <small className='text-light'>Experienced</small>
+              </div>
+            </article>
+            <article className='experience__details'>
+              <BsPatchCheckFill className="experience__details-icon" />
+              <div>
+                <h4>LangChain</h4>
+                <small className='text-light'>Intermediate</small>
+              </div>
+            </article>
+          </div>
+        </div>
       </div>
     </section>
   )

--- a/src/components/services/services.jsx
+++ b/src/components/services/services.jsx
@@ -85,12 +85,12 @@ const services = () => {
           </ul>
         </article>
                 {/* End of WebDev */}
-        <article className='service'>
-          <div className="service__head">
-            <h3>Content Creation</h3>
-          </div>
+          <article className='service'>
+            <div className="service__head">
+              <h3>Content Creation</h3>
+            </div>
 
-          <ul className='service__list'>
+            <ul className='service__list'>
             <li>
               <BiCheck className='service__list-icon'/>
               <p>Video Content</p>
@@ -118,6 +118,38 @@ const services = () => {
             <li>
               <BiCheck className='service__list-icon'/>
               <p> White papers</p>
+            </li>
+          </ul>
+        </article>
+        <article className='service'>
+          <div className="service__head">
+            <h3>AI Solutions</h3>
+          </div>
+
+          <ul className='service__list'>
+            <li>
+              <BiCheck className='service__list-icon'/>
+              <p>GPT Pro integration</p>
+            </li>
+            <li>
+              <BiCheck className='service__list-icon'/>
+              <p>Codex automation</p>
+            </li>
+            <li>
+              <BiCheck className='service__list-icon'/>
+              <p>Operator workflows</p>
+            </li>
+            <li>
+              <BiCheck className='service__list-icon'/>
+              <p>Custom chatbot development</p>
+            </li>
+            <li>
+              <BiCheck className='service__list-icon'/>
+              <p>Data analysis with AI</p>
+            </li>
+            <li>
+              <BiCheck className='service__list-icon'/>
+              <p>Model fine tuning</p>
             </li>
           </ul>
         </article>


### PR DESCRIPTION
## Summary
- list AI tools such as GPT Pro, Codex, Operator and more
- add AI Solutions to services section
- adjust experience grid for third column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685aef130ed8832185f5b2c8402da968